### PR TITLE
Persist step counter state

### DIFF
--- a/src/app/services/step-counter.service.ts
+++ b/src/app/services/step-counter.service.ts
@@ -100,10 +100,9 @@ export class StepCounterService implements OnDestroy {
     this._configSub = this.configService.config$.subscribe(async (config) => {
       clearInterval(this._intervalId);
 
-      const { tailStepTime_m, tailStepTime_ms } = this.getTailStepTime(config);
-
-      // reset steps when restarting from stopped state
       if (this.isUserCaught || timerState === 'stopped') {
+        // reset steps when restarting from stopped state
+
         this.userSteps = config.initialLead_km * 1000 / config.userStrideLength_m;
         this.tailSteps = 0;
         this.lastStepTimestamp = Date.now();
@@ -112,10 +111,16 @@ export class StepCounterService implements OnDestroy {
 
         this.updateSteps(config);
       } else if (timerState === 'paused') {
+        // reset last step time when resuming from paused state
+
         this.lastStepTimestamp = Date.now();
       }
 
+      const { tailStepTime_ms } = this.getTailStepTime(config);
+
       this._intervalId = setInterval(async () => {
+        // update subscribers if tail has gained one or more whole steps
+
         const tailSteps = Math.floor((Date.now() - this.lastStepTimestamp) / tailStepTime_ms);
 
         if (tailSteps > 0) {

--- a/src/app/services/step-counter.service.ts
+++ b/src/app/services/step-counter.service.ts
@@ -62,7 +62,12 @@ export class StepCounterService implements OnDestroy {
 
       this._intervalId = setInterval(() => {
         this.tailSteps++;
-        this.isUserCaught = this.tailSteps >= this.userSteps;
+
+        if (this.tailSteps >= this.userSteps) {
+          this.isUserCaught = true;
+
+          this.pauseChase();
+        }
 
         this.stepsCounted$.next({
           userSteps: this.userSteps,
@@ -70,10 +75,6 @@ export class StepCounterService implements OnDestroy {
           isUserCaught: this.isUserCaught,
           estimatedTimeRemaining_m: Math.floor((this.userSteps - this.tailSteps) * tailStepTime_m),
         });
-
-        if (this.isUserCaught) {
-          this.pauseChase();
-        }
       }, tailStepTime_m * 60 * 1000);
     });
 

--- a/src/app/services/step-counter.service.ts
+++ b/src/app/services/step-counter.service.ts
@@ -88,7 +88,7 @@ export class StepCounterService implements OnDestroy {
     this._configSub = this._configSub?.unsubscribe() || null;
 
     if (timerState === 'started') {
-      this.startChase();
+      this.startChase(timerState);
     }
 
     this.timerState$.next(timerState);
@@ -96,14 +96,14 @@ export class StepCounterService implements OnDestroy {
     return this.setSteps();
   }
 
-  startChase() {
+  startChase(timerState: 'started' | 'paused' | 'stopped') {
     this._configSub = this.configService.config$.subscribe(async (config) => {
       clearInterval(this._intervalId);
 
       const { tailStepTime_m, tailStepTime_ms } = this.getTailStepTime(config);
 
       // reset steps when restarting from stopped state
-      if (this.isUserCaught || await firstValueFrom(this.timerState$) === 'stopped') {
+      if (this.isUserCaught || timerState === 'stopped') {
         this.userSteps = config.initialLead_km * 1000 / config.userStrideLength_m;
         this.tailSteps = 0;
         this.lastStepTimestamp = Date.now();
@@ -111,7 +111,7 @@ export class StepCounterService implements OnDestroy {
         this.isUserCaught = false;
 
         this.updateSteps(config);
-      } else if (await firstValueFrom(this.timerState$) === 'paused') {
+      } else if (timerState === 'paused') {
         this.lastStepTimestamp = Date.now();
       }
 

--- a/src/app/services/step-counter.service.ts
+++ b/src/app/services/step-counter.service.ts
@@ -1,9 +1,12 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { ReplaySubject, Subscription, firstValueFrom } from 'rxjs';
 
+import { StorageService } from './storage.service';
 import { ConfigService } from './config.service';
 
 import { AVATARS_TAIL } from '../constants';
+
+const STORAGE_KEY = 'step_counter';
 
 @Injectable({
   providedIn: 'root'
@@ -20,17 +23,60 @@ export class StepCounterService implements OnDestroy {
 
   private userSteps = 0;
   private tailSteps = 0;
+  private lastStepTimestamp = 0;
+
   private isUserCaught = false;
 
   private _configSub: Subscription | null = null;
   private _intervalId: number | undefined = undefined;
 
-  constructor(private configService: ConfigService) {
+  constructor(private storageService: StorageService, private configService: ConfigService) {
+    setTimeout(async () => {
+      const config = await firstValueFrom(this.configService.config$);
 
+      // how long it takes the tail to cover the user's stride length
+      const tailStepTime_m = config.userStrideLength_m / (AVATARS_TAIL[config.tailIcon].velocity_kph * 1000) * 60;
+      const tailStepTime_ms = tailStepTime_m * 60 * 1000;
+
+      const { userSteps, tailSteps, lastStepTimestamp, timerState } = await this.getSteps();
+
+      this.userSteps = userSteps;
+      this.tailSteps = tailSteps;
+      this.lastStepTimestamp = lastStepTimestamp;
+      this.isUserCaught = this.tailSteps >= this.userSteps;
+
+      // update subscribers with initial values
+      this.stepsCounted$.next({
+        userSteps: this.userSteps,
+        tailSteps: this.tailSteps,
+        isUserCaught: this.isUserCaught,
+        estimatedTimeRemaining_m: Math.floor((this.userSteps - this.tailSteps) * tailStepTime_m),
+      });
+
+      this.changeMode(timerState);
+    });
   }
 
   ngOnDestroy() {
     this.changeMode('stopped');
+  }
+
+  async getSteps() {
+    return await this.storageService.get(STORAGE_KEY) || {
+      userSteps: 0,
+      tailSteps: 0,
+      lastStepTimestamp: 0,
+      timerState: 'stopped',
+    };
+  }
+
+  async setSteps() {
+    return this.storageService.set(STORAGE_KEY, {
+      userSteps: this.userSteps,
+      tailSteps: this.tailSteps,
+      lastStepTimestamp: this.lastStepTimestamp,
+      timerState: await firstValueFrom(this.timerState$),
+    });
   }
 
   changeMode(timerState: 'started' | 'paused' | 'stopped') {
@@ -43,6 +89,8 @@ export class StepCounterService implements OnDestroy {
     }
 
     this.timerState$.next(timerState);
+
+    this.setSteps();
   }
 
   startChase() {
@@ -57,6 +105,7 @@ export class StepCounterService implements OnDestroy {
       if (this.isUserCaught || await firstValueFrom(this.timerState$) === 'stopped') {
         this.userSteps = config.initialLead_km * 1000 / config.userStrideLength_m;
         this.tailSteps = 0;
+        this.lastStepTimestamp = Date.now();
         this.isUserCaught = false;
 
         // update subscribers with initial values
@@ -66,9 +115,9 @@ export class StepCounterService implements OnDestroy {
           isUserCaught: this.isUserCaught,
           estimatedTimeRemaining_m: Math.floor((this.userSteps - this.tailSteps) * tailStepTime_m),
         });
+      } else if (await firstValueFrom(this.timerState$) === 'paused') {
+        this.lastStepTimestamp = Date.now();
       }
-
-      let lastStepTimestamp = Date.now();
 
       this._intervalId = setInterval(() => {
         const now = Date.now();
@@ -79,8 +128,7 @@ export class StepCounterService implements OnDestroy {
 
         if (tailSteps > 0) {
           this.tailSteps += tailSteps;
-
-          lastStepTimestamp += tailStepTime_ms * tailSteps;
+          this.lastStepTimestamp += tailStepTime_ms * tailSteps;
 
           if (this.tailSteps >= this.userSteps) {
             this.isUserCaught = true;

--- a/src/app/services/step-counter.service.ts
+++ b/src/app/services/step-counter.service.ts
@@ -42,24 +42,24 @@ export class StepCounterService implements OnDestroy {
     this._configSub = this.configService.config$.subscribe(config => {
       clearInterval(this._intervalId);
 
+      // how long it takes the tail to cover the user's stride length
+      const tailStepTime_m = config.userStrideLength_m / (AVATARS_TAIL[config.tailIcon].velocity_kph * 1000) * 60;
+      const tailStepTime_ms = tailStepTime_m * 60 * 1000;
+
       // reset steps when restarting from stopped state
       if (this.isUserCaught || this.timerState$.getValue() === 'stopped') {
         this.userSteps = config.initialLead_km * 1000 / config.userStrideLength_m;
         this.tailSteps = 0;
         this.isUserCaught = false;
+
+        // update subscribers with initial values
+        this.stepsCounted$.next({
+          userSteps: this.userSteps,
+          tailSteps: this.tailSteps,
+          isUserCaught: this.isUserCaught,
+          estimatedTimeRemaining_m: Math.floor((this.userSteps - this.tailSteps) * tailStepTime_m),
+        });
       }
-
-      // how long it takes the tail to cover the user's stride length
-      const tailStepTime_m = config.userStrideLength_m / (AVATARS_TAIL[config.tailIcon].velocity_kph * 1000) * 60;
-      const tailStepTime_ms = tailStepTime_m * 60 * 1000;
-
-      // update subscribers with initial values
-      this.stepsCounted$.next({
-        userSteps: this.userSteps,
-        tailSteps: this.tailSteps,
-        isUserCaught: this.isUserCaught,
-        estimatedTimeRemaining_m: Math.floor((this.userSteps - this.tailSteps) * tailStepTime_m),
-      });
 
       let lastStepTimestamp = Date.now();
 

--- a/src/app/services/step-counter.service.ts
+++ b/src/app/services/step-counter.service.ts
@@ -53,7 +53,7 @@ export class StepCounterService implements OnDestroy {
         estimatedTimeRemaining_m: Math.floor((this.userSteps - this.tailSteps) * tailStepTime_m),
       });
 
-      this.changeMode(timerState);
+      await this.changeMode(timerState);
     });
   }
 
@@ -79,7 +79,7 @@ export class StepCounterService implements OnDestroy {
     });
   }
 
-  changeMode(timerState: 'started' | 'paused' | 'stopped') {
+  async changeMode(timerState: 'started' | 'paused' | 'stopped') {
     clearInterval(this._intervalId);
 
     this._configSub = this._configSub?.unsubscribe() || null;
@@ -90,7 +90,7 @@ export class StepCounterService implements OnDestroy {
 
     this.timerState$.next(timerState);
 
-    this.setSteps();
+    return this.setSteps();
   }
 
   startChase() {
@@ -119,7 +119,7 @@ export class StepCounterService implements OnDestroy {
         this.lastStepTimestamp = Date.now();
       }
 
-      this._intervalId = setInterval(() => {
+      this._intervalId = setInterval(async () => {
         const tailSteps = Math.floor((Date.now() - this.lastStepTimestamp) / tailStepTime_ms);
 
         if (tailSteps > 0) {
@@ -129,7 +129,7 @@ export class StepCounterService implements OnDestroy {
           if (this.tailSteps >= this.userSteps) {
             this.isUserCaught = true;
 
-            this.changeMode('paused');
+            await this.changeMode('paused');
           }
 
           this.stepsCounted$.next({

--- a/src/app/services/step-counter.service.ts
+++ b/src/app/services/step-counter.service.ts
@@ -58,7 +58,7 @@ export class StepCounterService implements OnDestroy {
   }
 
   ngOnDestroy() {
-    this.changeMode('stopped');
+    this._configSub?.unsubscribe();
   }
 
   async getSteps() {

--- a/src/app/services/step-counter.service.ts
+++ b/src/app/services/step-counter.service.ts
@@ -30,7 +30,19 @@ export class StepCounterService implements OnDestroy {
   }
 
   ngOnDestroy() {
-    this.stopChase();
+    this.changeMode('stopped');
+  }
+
+  changeMode(timerState: 'started' | 'paused' | 'stopped') {
+    clearInterval(this._intervalId);
+
+    this._configSub = this._configSub?.unsubscribe() || null;
+
+    if (timerState === 'started') {
+      this.startChase();
+    }
+
+    this.timerState$.next(timerState);
   }
 
   startChase() {
@@ -73,7 +85,7 @@ export class StepCounterService implements OnDestroy {
           if (this.tailSteps >= this.userSteps) {
             this.isUserCaught = true;
 
-            this.pauseChase();
+            this.changeMode('paused');
           }
 
           this.stepsCounted$.next({
@@ -85,23 +97,5 @@ export class StepCounterService implements OnDestroy {
         }
       }, Math.max(1000, tailStepTime_ms));
     });
-
-    this.timerState$.next('started');
-  }
-
-  pauseChase() {
-    clearInterval(this._intervalId);
-
-    this._configSub = this._configSub?.unsubscribe() || null;
-
-    this.timerState$.next('paused');
-  }
-
-  stopChase() {
-    clearInterval(this._intervalId);
-
-    this._configSub = this._configSub?.unsubscribe() || null;
-
-    this.timerState$.next('stopped');
   }
 }

--- a/src/app/services/step-counter.service.ts
+++ b/src/app/services/step-counter.service.ts
@@ -41,6 +41,7 @@ export class StepCounterService implements OnDestroy {
       this.userSteps = userSteps;
       this.tailSteps = tailSteps;
       this.lastStepTimestamp = lastStepTimestamp;
+
       this.isUserCaught = this.tailSteps >= this.userSteps;
 
       // update subscribers with initial values
@@ -102,6 +103,7 @@ export class StepCounterService implements OnDestroy {
         this.userSteps = config.initialLead_km * 1000 / config.userStrideLength_m;
         this.tailSteps = 0;
         this.lastStepTimestamp = Date.now();
+
         this.isUserCaught = false;
 
         // update subscribers with initial values

--- a/src/app/services/step-counter.service.ts
+++ b/src/app/services/step-counter.service.ts
@@ -120,11 +120,7 @@ export class StepCounterService implements OnDestroy {
       }
 
       this._intervalId = setInterval(() => {
-        const now = Date.now();
-
-        const timeDiff = now - lastStepTimestamp;
-
-        const tailSteps = Math.floor(timeDiff / tailStepTime_ms);
+        const tailSteps = Math.floor((Date.now() - this.lastStepTimestamp) / tailStepTime_ms);
 
         if (tailSteps > 0) {
           this.tailSteps += tailSteps;

--- a/src/app/services/storage.service.ts
+++ b/src/app/services/storage.service.ts
@@ -20,4 +20,8 @@ export class StorageService {
     return this.storage.then(storage => storage.set(key, value));
   }
 
+  async remove(key: string) {
+    return this.storage.then(storage => storage.remove(key));
+  }
+
 }

--- a/src/app/shared/app-header/app-header.component.html
+++ b/src/app/shared/app-header/app-header.component.html
@@ -12,7 +12,7 @@
         type="button"
         fill="clear"
         color="dark"
-        (click)="onClick('start')"
+        (click)="onClick('started')"
       >
         <ion-icon slot="icon-only" name="play-circle-outline"></ion-icon>
       </ion-button>
@@ -22,7 +22,7 @@
         type="button"
         fill="clear"
         color="dark"
-        (click)="onClick('pause')"
+        (click)="onClick('paused')"
       >
         <ion-icon slot="icon-only" name="pause-circle-outline"></ion-icon>
       </ion-button>
@@ -32,7 +32,7 @@
         fill="clear"
         color="dark"
         [disabled]="timerStatus === 'stopped'"
-        (click)="onClick('stop')"
+        (click)="onClick('stopped')"
       >
         <ion-icon slot="icon-only" name="stop-circle-outline"></ion-icon>
       </ion-button>

--- a/src/app/shared/app-header/app-header.component.ts
+++ b/src/app/shared/app-header/app-header.component.ts
@@ -24,23 +24,7 @@ export class AppHeaderComponent  implements OnInit {
 
   }
 
-  onClick(action: string) {
-    switch (action) {
-      case 'start':
-        this.stepCounterService.startChase();
-
-        break;
-      case 'pause':
-        this.stepCounterService.pauseChase();
-
-        break;
-      case 'stop':
-        this.stepCounterService.stopChase();
-
-        break;
-      default:
-        // do nothing
-        break;
-    }
+  onClick(timerState: 'started' | 'paused' | 'stopped') {
+    this.stepCounterService.changeMode(timerState);
   }
 }


### PR DESCRIPTION
This persists the step counter state (whenever the timer state changes) to local storage. This allows for the app to continue across page refreshes or even if the app is closed. Since we store a timestamp for the last time the state was saved, we allow for an indefinite amount of time between the save and the reload by deriving what we need from that.